### PR TITLE
Release/v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db-cache-redis",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Redis cache implementation for orbit-db",
   "main": "src/Cache.js",
   "scripts": {


### PR DESCRIPTION
Support new orbit db v0.22 cache implementation. Orbitdb also made some nice changes to support multiple storage layers, so could pass redis store into their implementation instead, but that would require a data migration on our end, while this does not. We may also want to make additional changes that are easier to implement here than at another layer, so this thin interface for us still makes sense. 